### PR TITLE
add basic STUN client (RTC 5389)

### DIFF
--- a/stun/attr_channel_number.go
+++ b/stun/attr_channel_number.go
@@ -1,8 +1,6 @@
 package stun
 
 import (
-	"encoding/binary"
-
 	"github.com/pkg/errors"
 )
 
@@ -17,7 +15,7 @@ type ChannelNumber struct {
 // Pack a ChannelNumber attribute, adding it to the passed message
 func (x *ChannelNumber) Pack(message *Message) error {
 	v := make([]byte, 2)
-	binary.BigEndian.PutUint16(v, x.ChannelNumber)
+	enc.PutUint16(v, x.ChannelNumber)
 	message.AddAttribute(AttrChannelNumber, v)
 	return nil
 }
@@ -30,7 +28,7 @@ func (x *ChannelNumber) Unpack(message *Message, rawAttribute *RawAttribute) err
 		return errors.Errorf("invalid channel number length %d != %d (expected)", len(v), 2)
 	}
 
-	x.ChannelNumber = binary.BigEndian.Uint16(v[:2])
+	x.ChannelNumber = enc.Uint16(v[:2])
 
 	return nil
 }

--- a/stun/attr_fingerprint.go
+++ b/stun/attr_fingerprint.go
@@ -1,7 +1,6 @@
 package stun
 
 import (
-	"encoding/binary"
 	"hash/crc32"
 
 	"github.com/pkg/errors"
@@ -30,7 +29,7 @@ func (s *Fingerprint) Pack(message *Message) error {
 	message.Length += attrHeaderLength + fingerprintLength
 	message.CommitLength()
 	v := make([]byte, fingerprintLength)
-	binary.BigEndian.PutUint32(v, calculateFingerprint(message.Raw))
+	enc.PutUint32(v, calculateFingerprint(message.Raw))
 	message.Length = prevLen
 
 	message.AddAttribute(AttrFingerprint, v)
@@ -39,7 +38,7 @@ func (s *Fingerprint) Pack(message *Message) error {
 
 func (s *Fingerprint) Unpack(message *Message, rawAttribute *RawAttribute) error {
 
-	s.Fingerprint = binary.BigEndian.Uint32(rawAttribute.Value)
+	s.Fingerprint = enc.Uint32(rawAttribute.Value)
 
 	expected := calculateFingerprint(message.Raw[:rawAttribute.Offset])
 

--- a/stun/attr_lifetime.go
+++ b/stun/attr_lifetime.go
@@ -1,8 +1,6 @@
 package stun
 
 import (
-	"encoding/binary"
-
 	"github.com/pkg/errors"
 )
 
@@ -12,7 +10,7 @@ type Lifetime struct {
 
 func (x *Lifetime) Pack(message *Message) error {
 	v := make([]byte, 4)
-	binary.BigEndian.PutUint32(v, x.Duration)
+	enc.PutUint32(v, x.Duration)
 	message.AddAttribute(AttrLifetime, v)
 	return nil
 }
@@ -24,7 +22,7 @@ func (x *Lifetime) Unpack(message *Message, rawAttribute *RawAttribute) error {
 		return errors.Errorf("invalid lifetime length %d != %d (expected)", len(v), 4)
 	}
 
-	x.Duration = binary.BigEndian.Uint32(v)
+	x.Duration = enc.Uint32(v)
 
 	return nil
 }

--- a/stun/attr_unknown_attributes.go
+++ b/stun/attr_unknown_attributes.go
@@ -1,8 +1,6 @@
 package stun
 
 import (
-	"encoding/binary"
-
 	"github.com/pkg/errors"
 )
 
@@ -43,7 +41,7 @@ func (u *UnknownAttributes) Pack(message *Message) error {
 
 	var v [8]byte
 	for i, attr := range u.Attributes {
-		binary.BigEndian.PutUint16(v[i*2:], uint16(attr))
+		enc.PutUint16(v[i*2:], uint16(attr))
 	}
 
 	message.AddAttribute(AttrUnknownAttributes, v[0:])

--- a/stun/attr_xor_mapped_address.go
+++ b/stun/attr_xor_mapped_address.go
@@ -13,6 +13,7 @@ type XorMappedAddress struct {
 	XorAddress
 }
 
+// Pack writes an XorMappedAddress into a message
 func (x *XorMappedAddress) Pack(message *Message) error {
 	v, err := x.packInner(message)
 	if err != nil {

--- a/stun/channel_data.go
+++ b/stun/channel_data.go
@@ -1,8 +1,6 @@
 package stun
 
 import (
-	"encoding/binary"
-
 	"github.com/pkg/errors"
 )
 
@@ -29,7 +27,7 @@ func NewChannelData(packet []byte) (*ChannelData, error) {
 //  field in the ChannelData message and channel numbers fall in the
 //  range 0x4000 - 0x7FFF).
 func getChannelNumber(header []byte) (uint16, error) {
-	cn := binary.BigEndian.Uint16(header)
+	cn := enc.Uint16(header)
 	if cn < 0x4000 || cn > 0x7FFF {
 		return 0, errors.Errorf("ChannelNumber is out of range: %d", cn)
 	}
@@ -37,5 +35,5 @@ func getChannelNumber(header []byte) (uint16, error) {
 }
 
 func getChannelLength(header []byte) uint16 {
-	return binary.BigEndian.Uint16(header[2:])
+	return enc.Uint16(header[2:])
 }

--- a/stun/client.go
+++ b/stun/client.go
@@ -1,0 +1,75 @@
+package stun
+
+import (
+	"net"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	maxMessageSize = 1280
+
+	// ErrResponseTooBig is returned if more than maxMessageSize bytes are returned in the response
+	// see https://tools.ietf.org/html/rfc5389#section-7 for the size limit
+	ErrResponseTooBig = errors.New("received too much data")
+)
+
+// Client is a STUN client that sents STUN requests and receives STUN responses
+type Client struct {
+	conn net.Conn
+}
+
+// NewClient creates a configured STUN client
+func NewClient(protocol, server string, deadline time.Duration) (*Client, error) {
+	dialer := &net.Dialer{
+		Timeout: deadline,
+	}
+	conn, err := dialer.Dial(protocol, server)
+	if err != nil {
+		return nil, err
+	}
+	conn.SetReadDeadline(time.Now().Add(deadline))
+	conn.SetWriteDeadline(time.Now().Add(deadline))
+	return &Client{
+		conn: conn,
+	}, nil
+}
+
+func generateSTUNTransactionID() []byte {
+	return GenerateTransactionId()[:TransactionIDSize]
+}
+
+// Request executes a STUN request against the clients server
+func (c *Client) Request() (*Message, error) {
+	host, port, err := netAddrIPPort(c.conn.RemoteAddr())
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := Build(ClassRequest, MethodBinding, GenerateTransactionId(), &XorMappedAddress{
+		XorAddress: XorAddress{
+			IP:   host,
+			Port: port,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = c.conn.Write(req.Pack())
+	if err != nil {
+		return nil, err
+	}
+
+	bs := make([]byte, maxMessageSize)
+	n, err := c.conn.Read(bs)
+	if err != nil {
+		return nil, err
+	}
+	if n > maxMessageSize {
+		return nil, ErrResponseTooBig
+	}
+
+	return NewMessage(bs[:n])
+}

--- a/stun/client_test.go
+++ b/stun/client_test.go
@@ -1,0 +1,27 @@
+package stun
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestClient_Request(t *testing.T) {
+	client, err := NewClient("udp", "stun.l.google.com:19302", time.Second*5)
+	if err != nil {
+		t.Fatalf("Failed to create STUN client: %v", err)
+	}
+	resp, err := client.Request()
+	if err != nil {
+		t.Fatalf("Failed to send a STUN Request to: %v", err)
+	}
+	attr, ok := resp.GetOneAttribute(AttrXORMappedAddress)
+	if !ok {
+		t.Fatalf("Failed to get XOR mapped address")
+	}
+	var addr XorAddress
+	if err := addr.Unpack(resp, attr); err != nil {
+		t.Fatalf("Unpacking created error: %#v", err.Error())
+	}
+	fmt.Printf("remote address: %s:%d\n", addr.IP.String(), addr.Port)
+}

--- a/stun/encoding.go
+++ b/stun/encoding.go
@@ -1,0 +1,9 @@
+package stun
+
+import "encoding/binary"
+
+// STUN expects all messages to be BigEndian encoded
+
+var (
+	enc = binary.BigEndian
+)

--- a/stun/message.go
+++ b/stun/message.go
@@ -95,6 +95,9 @@ const (
 	magicCookieLength   int = 4
 	transactionIDStart  int = 4
 	transactionIDLength int = 16
+
+	// TransactionIDSize is the size of the transaction according to RFC 5389: 96 bits
+	TransactionIDSize = 96 / 8
 )
 
 type Message struct {

--- a/stun/message.go
+++ b/stun/message.go
@@ -204,6 +204,7 @@ func getAttribute(attribute []byte, offset int) *RawAttribute {
 	return &RawAttribute{typ, len, attribute[attrValueStart : attrValueStart+len], pad, offset}
 }
 
+// NewMessage parses a binary STUN message into a Message struct
 // TODO Break this apart, too big
 func NewMessage(packet []byte) (*Message, error) {
 

--- a/stun/message_builder.go
+++ b/stun/message_builder.go
@@ -4,9 +4,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-type MessageBuilder struct {
-}
-
 func Build(class MessageClass, method Method, transactionID []byte, attrs ...Attribute) (*Message, error) {
 
 	m := &Message{

--- a/stun/xor_address.go
+++ b/stun/xor_address.go
@@ -1,7 +1,6 @@
 package stun
 
 import (
-	"encoding/binary"
 	"io"
 	"net"
 
@@ -97,9 +96,9 @@ func (x *XorAddress) packInner(message *Message) ([]byte, error) {
 	v := make([]byte, len)
 
 	// Family
-	binary.BigEndian.PutUint16(v[familyStart:familyStart+familyLength], family)
+	enc.PutUint16(v[familyStart:familyStart+familyLength], family)
 	// Port
-	binary.BigEndian.PutUint16(v[portStart:portStart+portLength], uint16(x.Port))
+	enc.PutUint16(v[portStart:portStart+portLength], uint16(x.Port))
 	xor(v[portStart:portStart+portLength], v[portStart:portStart+portLength], message.TransactionID[0:2])
 	// Address
 	copy(v[addressStart:], ip)
@@ -115,7 +114,7 @@ func (x *XorAddress) Unpack(message *Message, rawAttribute *RawAttribute) error 
 		return io.ErrUnexpectedEOF
 	}
 
-	family := binary.BigEndian.Uint16(v[familyStart : familyStart+familyLength])
+	family := enc.Uint16(v[familyStart : familyStart+familyLength])
 
 	if family != familyIPv4 && family != familyIPv6 {
 		return errors.Errorf("invalid family %d (expected IPv4(%d) or IPv6(%d)", family, familyIPv4, familyIPv6)
@@ -129,7 +128,7 @@ func (x *XorAddress) Unpack(message *Message, rawAttribute *RawAttribute) error 
 	// Transaction ID [0,2] is top half of magic cookie
 	xor(p[:], v[portStart:portStart+portLength], message.TransactionID[0:2])
 
-	x.Port = int(binary.BigEndian.Uint16(p[:]))
+	x.Port = int(enc.Uint16(p[:]))
 
 	al := net.IPv4len
 	if family == familyIPv6 {


### PR DESCRIPTION
the STUN client can only send a `Request` for now, no indication.

It works with both `TCP` and `UDP`, verified using [STUNTMAN](https://sourceforge.net/projects/stuntman/?source=typ_redirect) locally.